### PR TITLE
introduce hang argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 gh-pages
+.DS_Store
+.RData
+.Rhistory
+.Rproj.user
+vignettes/*.html

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,12 @@ check3: rd build2
 	cd ..;\
 	R CMD check --ignore-vignettes $(PKGNAME)_$(PKGVERS).tar.gz
 
+bignore:
+	Rscript -e 'usethis::use_build_ignore(c("Makefile", "README.md", "README.Rmd", "CONDUCT.md", ".Rproj.user", ".Rproj"))'
+
+gignore:
+	Rscript -e 'usethis::use_git_ignore(c(".DS_Store", ".RData", ".Rhistory", ".Rproj.user", "vignettes/*.html"))'
+
 bioccheck:
 	cd ..;\
 	Rscript -e 'BiocCheck::BiocCheck("$(PKGNAME)_$(PKGVERS).tar.gz")'

--- a/R/autoplot.R
+++ b/R/autoplot.R
@@ -5,13 +5,16 @@ ggplot2::autoplot
 
 
 ## autoplot methods
-## 
 ## autoplot methods for hierarchical clustering results
+
 ##' @title autoplot
 ##' @rdname autoplot
 ##' @param object input object
 ##' @param layout layout for plotting the tree
 ##' @param ladderize whether ladderize the tree (default FALSE)
+##' @param hang numeric The fraction of the tree plot height by which labels
+##' should hang below the rest of the plot. A negative value will cause the 
+##' labels to hang down from 0.
 ##' @param ... additional paramters that passed to ggtree
 ##' @return ggtree object
 ##' @importFrom ggtree ggtree
@@ -26,8 +29,8 @@ ggplot2::autoplot
 ##' d <- dist(USArrests)
 ##' hc <- hclust(d, "ave")
 ##' autoplot(hc) + geom_tiplab()
-autoplot.hclust <- function(object, layout = "dendrogram", ladderize = FALSE, ...) {
-    p <- ggtree(object, ladderize = ladderize, layout=layout, ...) 
+autoplot.hclust <- function(object, layout = "dendrogram", ladderize = FALSE, hang = 0.1, ...) {
+    p <- ggtree(object, ladderize = ladderize, layout=layout, hang = hang, ...) 
     #geom_tiplab() + 
 
     if (is.function(layout)) {
@@ -82,9 +85,9 @@ autoplot.twins <- autoplot.hclust
 ##' @importFrom tidytree offspring
 ##' @export
 autoplot.pvclust <- function(object, layout = "dendrogram", ladderize = FALSE, 
-                            label_edge = FALSE, pvrect = FALSE, alpha = 0.95, ...) {
+                            label_edge = FALSE, pvrect = FALSE, alpha = 0.95, hang = 0.1, ...) {
 
-    x <-  as.treedata(object)
+    x <-  as.treedata(object, hang = hang)
                             
     p <- autoplot.hclust(x, layout=layout, ladderize=ladderize, ...) +
         geom_nodelab(aes_(label=~au, color="au"), angle=0, vjust=-.5, hjust=1.3) +

--- a/man/autoplot.Rd
+++ b/man/autoplot.Rd
@@ -13,17 +13,17 @@
 \alias{autoplot.pvclust}
 \title{Objects exported from other packages}
 \usage{
-\method{autoplot}{hclust}(object, layout = "dendrogram", ladderize = FALSE, ...)
+\method{autoplot}{hclust}(object, layout = "dendrogram", ladderize = FALSE, hang = 0.1, ...)
 
-\method{autoplot}{linkage}(object, layout = "dendrogram", ladderize = FALSE, ...)
+\method{autoplot}{linkage}(object, layout = "dendrogram", ladderize = FALSE, hang = 0.1, ...)
 
-\method{autoplot}{dendrogram}(object, layout = "dendrogram", ladderize = FALSE, ...)
+\method{autoplot}{dendrogram}(object, layout = "dendrogram", ladderize = FALSE, hang = 0.1, ...)
 
-\method{autoplot}{agnes}(object, layout = "dendrogram", ladderize = FALSE, ...)
+\method{autoplot}{agnes}(object, layout = "dendrogram", ladderize = FALSE, hang = 0.1, ...)
 
-\method{autoplot}{diana}(object, layout = "dendrogram", ladderize = FALSE, ...)
+\method{autoplot}{diana}(object, layout = "dendrogram", ladderize = FALSE, hang = 0.1, ...)
 
-\method{autoplot}{twins}(object, layout = "dendrogram", ladderize = FALSE, ...)
+\method{autoplot}{twins}(object, layout = "dendrogram", ladderize = FALSE, hang = 0.1, ...)
 
 \method{autoplot}{pvclust}(
   object,
@@ -32,6 +32,7 @@
   label_edge = FALSE,
   pvrect = FALSE,
   alpha = 0.95,
+  hang = 0.1,
   ...
 )
 }
@@ -41,6 +42,10 @@
 \item{layout}{layout for plotting the tree}
 
 \item{ladderize}{whether ladderize the tree (default FALSE)}
+
+\item{hang}{numeric The fraction of the tree plot height by which labels
+should hang below the rest of the plot. A negative value will cause the
+labels to hang down from 0.}
 
 \item{...}{additional paramters that passed to ggtree}
 }


### PR DESCRIPTION
+ introduce hang argument to control the tip edge length.

```
library(ggtreeDendro)
library(pvclust)
data(Boston, package = "MASS")
set.seed(123)
boston.pv <- pvclust(Boston, nboot=100, parallel=TRUE)
autoplot(boston.pv, pvrect = TRUE)
```
![xx](https://user-images.githubusercontent.com/17870644/185566393-d879ce96-9a14-4d6b-8dc4-b2a5c8514c1b.PNG)
